### PR TITLE
個人情報文言エリアのレスポンシブ対応.

### DIFF
--- a/common/css/smp_form.css
+++ b/common/css/smp_form.css
@@ -228,6 +228,10 @@ ss_warning_label{
     .ss_btnArea{
         margin: 30px 0px;
     }
+    /* 2021.12.12.nagamine. */
+    .ss_privacy .ss_grid{
+        width: 100%;
+    }
 }
 @media screen and (max-width: 600px), print {
     .tabContent > li {


### PR DESCRIPTION
800px以下の時に個人情報文言エリアの幅を100%に修正.